### PR TITLE
Add net installer script

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,3 +60,19 @@ directory or an empty folder.
 The script uses `git` to fetch the latest changes from the configured
 repository. You can change the repository URL by editing the `REPO_URL`
 variable in `update/update.sh`.
+
+## Net Installer
+
+A script `net_installer.sh` is provided for installing OpenB directly from the
+internet. The script clones this repository to a temporary directory, builds the
+browser and copies the resulting `openb` binary to `/usr/local/bin`.
+
+Run it with:
+
+```bash
+./net_installer.sh
+```
+
+Root privileges are required for the installation step. Ensure the required build
+dependencies for GTK and WebKit2GTK are installed on your system.
+

--- a/net_installer.sh
+++ b/net_installer.sh
@@ -1,0 +1,53 @@
+#!/bin/sh
+# Net Installer for OpenB Web Browser
+# This script clones the OpenB source from the internet,
+# builds it and installs the binary to /usr/local/bin.
+
+set -e
+
+REPO_URL="https://github.com/Kgkkjjj/WebBrowser.git"
+BRANCH="codex/build-web-browser-with-gtk-3-gui"
+INSTALL_DIR="/usr/local/bin"
+
+command -v git >/dev/null 2>&1 || {
+    echo "git is required but not installed." >&2
+    exit 1
+}
+
+command -v make >/dev/null 2>&1 || {
+    echo "make is required but not installed." >&2
+    exit 1
+}
+
+TMP_DIR=$(mktemp -d)
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+cd "$TMP_DIR"
+echo "Cloning source..."
+# clone only the specified branch
+if ! git clone --branch "$BRANCH" --depth 1 "$REPO_URL" openb-source; then
+    echo "Failed to clone repository" >&2
+    exit 1
+fi
+
+cd openb-source
+
+echo "Building..."
+if ! make; then
+    echo "Build failed" >&2
+    exit 1
+fi
+
+if [ $(id -u) -ne 0 ]; then
+    if command -v sudo >/dev/null 2>&1; then
+        echo "Installing to $INSTALL_DIR requires root privileges."
+        sudo cp openb "$INSTALL_DIR/" || { echo "Install failed" >&2; exit 1; }
+    else
+        echo "Run this script as root to install the binary." >&2
+        exit 1
+    fi
+else
+    cp openb "$INSTALL_DIR/" || { echo "Install failed" >&2; exit 1; }
+fi
+
+echo "Installation complete. You can run the browser with 'openb'."


### PR DESCRIPTION
## Summary
- add a `net_installer.sh` script for fetching, building and installing the OpenB browser
- document usage in README

## Testing
- `make` *(fails: gtk and webkit2gtk development libraries missing)*

------
https://chatgpt.com/codex/tasks/task_e_68403b9153d88330a60fb45c4ded18d8