### PR TITLE
Add GTK desktop GUI for LKJ IDE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@
 *.exe
 *.out
 *.app
+lkj

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,28 @@
+.RECIPEPREFIX := >
+CC=gcc
+CFLAGS=-Wall -Wextra -Wpedantic -std=c17 -O2
+LDFLAGS=-lpthread
+
+GTK_PACKAGES=gtk+-3.0 webkit2gtk-4.1
+GTK_CFLAGS=$(shell pkg-config --cflags $(GTK_PACKAGES))
+GTK_LIBS=$(shell pkg-config --libs $(GTK_PACKAGES))
+
+SRC=$(wildcard src/*.c)
+OBJ=$(SRC:.c=.o)
+BIN=lkj
+
+.PHONY: all clean run
+
+all: $(BIN)
+
+$(BIN): $(OBJ)
+>$(CC) $(CFLAGS) $(GTK_CFLAGS) -o $@ $^ $(LDFLAGS) $(GTK_LIBS)
+
+%.o: %.c
+>$(CC) $(CFLAGS) $(GTK_CFLAGS) -c -o $@ $<
+
+run: $(BIN)
+>./$(BIN)
+
+clean:
+>rm -f $(OBJ) $(BIN)

--- a/README.md
+++ b/README.md
@@ -1,0 +1,32 @@
+# LKJ Web IDE
+
+LKJ is a minimal POSIX socket server and browser IDE combo so you can browse, edit, and execute commands inside a Linux workspace.
+
+## Build & Run
+
+```bash
+# optional: export LKJ_HOST, LKJ_PORT, LKJ_WORKSPACE, LKJ_STATIC
+make clean && make
+./lkj
+```
+
+By default the server binds to `0.0.0.0:8080` and serves static assets from `assets/`. The workspace root defaults to the current directory.
+
+## Desktop GUI window
+
+A GTK+WebKit desktop window is bundled so you can edit and preview sites/apps without leaving your Linux desktop:
+
+- GTK 3 and WebKit2GTK 4.1 headers are required (`libgtk-3-dev libwebkit2gtk-4.1-dev` on Ubuntu).
+- When a graphical display is available, `lkj` automatically starts the server in the background and opens a native window that loads the IDE at `http://127.0.0.1:<port>`.
+- If no GUI is detected (e.g., running headless), the server runs normally and you can open the IDE in your browser at `http://<host>:<port>`.
+
+## API surface
+
+- `GET /api/files?path=<path>` – list directory contents.
+- `GET /api/file?path=<path>` – read a file.
+- `POST /api/file?path=<path>` – write file content (request body is raw file bytes).
+- `POST /api/exec` – execute a shell command (body contains the command line).
+
+## Static assets
+
+The `assets/index.html` file implements a single-page web IDE with explorer, editor, and command console panes.

--- a/assets/index.html
+++ b/assets/index.html
@@ -1,0 +1,195 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>LKJ IDE</title>
+  <style>
+    :root {
+      --bg: #0e1116;
+      --panel: #151a21;
+      --text: #e3ecf5;
+      --accent: #3fa9f5;
+      --border: #1f2732;
+    }
+    body {
+      margin: 0;
+      padding: 0;
+      font-family: "Fira Code", "SFMono-Regular", Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+      background: var(--bg);
+      color: var(--text);
+      height: 100vh;
+      display: grid;
+      grid-template-rows: 56px 1fr;
+    }
+    header {
+      background: #0a0d12;
+      border-bottom: 1px solid var(--border);
+      display: flex;
+      align-items: center;
+      padding: 0 16px;
+      gap: 16px;
+    }
+    header .title {
+      font-weight: 700;
+      letter-spacing: 1px;
+    }
+    header button {
+      background: var(--accent);
+      color: #0a0d12;
+      border: none;
+      padding: 10px 14px;
+      border-radius: 6px;
+      cursor: pointer;
+      font-weight: 700;
+      transition: transform 120ms ease;
+    }
+    header button:hover { transform: translateY(-1px); }
+    main { display: grid; grid-template-columns: 280px 1fr 420px; height: 100%; }
+    .panel {
+      border-right: 1px solid var(--border);
+      background: var(--panel);
+      overflow: auto;
+    }
+    .panel h2 {
+      margin: 12px;
+      font-size: 14px;
+      text-transform: uppercase;
+      color: #8fa3c5;
+      letter-spacing: 0.05em;
+    }
+    #explorer ul { list-style: none; padding: 0 12px 24px 12px; }
+    #explorer li {
+      padding: 6px 8px;
+      border-radius: 6px;
+      cursor: pointer;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      transition: background 120ms ease;
+    }
+    #explorer li:hover { background: #1d2430; }
+    #editor { padding: 12px; background: #0f131b; }
+    #editor textarea {
+      width: 100%;
+      height: 80vh;
+      background: #0c1016;
+      color: var(--text);
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      padding: 12px;
+      font-size: 14px;
+      resize: vertical;
+    }
+    #terminal { padding: 12px; background: #0f131b; border-left: 1px solid var(--border); }
+    #terminal pre {
+      background: #0c1016;
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      padding: 12px;
+      height: 70vh;
+      overflow: auto;
+    }
+    #terminal input {
+      width: 100%;
+      padding: 10px;
+      border-radius: 6px;
+      border: 1px solid var(--border);
+      background: #0c1016;
+      color: var(--text);
+      margin-top: 12px;
+    }
+    .pill { font-size: 11px; padding: 2px 6px; border-radius: 10px; background: #2b3340; color: #c4d2eb; }
+    .row { display: flex; gap: 8px; align-items: center; }
+  </style>
+</head>
+<body>
+  <header>
+    <div class="title">LKJ • Hyper-Integrated Web IDE</div>
+    <button onclick="reloadExplorer()">Refresh Files</button>
+    <button onclick="saveFile()">Save</button>
+    <button onclick="executeCommand()">Run Command</button>
+    <div id="status"></div>
+  </header>
+  <main>
+    <section class="panel" id="explorer">
+      <h2>Workspace</h2>
+      <ul id="file-list"></ul>
+    </section>
+    <section id="editor">
+      <h2>Editor</h2>
+      <div class="row">
+        <div>Editing:</div>
+        <div id="current-file" class="pill">(none)</div>
+      </div>
+      <textarea id="editor-area" placeholder="Select a file to edit"></textarea>
+    </section>
+    <section id="terminal">
+      <h2>Command Forge</h2>
+      <pre id="terminal-output">$ ready</pre>
+      <input id="command-input" placeholder="e.g. ls -la" onkeydown="if(event.key==='Enter') executeCommand();" />
+    </section>
+  </main>
+  <script>
+    let currentPath = null;
+
+    function setStatus(message) {
+      const status = document.getElementById('status');
+      status.textContent = message;
+      setTimeout(() => status.textContent = '', 3000);
+    }
+
+    async function reloadExplorer(path = '.') {
+      const res = await fetch(`/api/files?path=${encodeURIComponent(path)}`);
+      if (!res.ok) { setStatus('Failed to load explorer'); return; }
+      const data = await res.json();
+      const list = document.getElementById('file-list');
+      list.innerHTML = '';
+      data.entries.forEach(entry => {
+        const li = document.createElement('li');
+        li.innerHTML = `<span>${entry.name}</span><span class="pill">${entry.kind}</span>`;
+        li.onclick = () => {
+          const nextPath = `${path}/${entry.name}`;
+          if (entry.kind === 'dir') reloadExplorer(nextPath);
+          else loadFile(nextPath);
+        };
+        list.appendChild(li);
+      });
+    }
+
+    async function loadFile(path) {
+      const res = await fetch(`/api/file?path=${encodeURIComponent(path)}`);
+      if (!res.ok) { setStatus('Failed to load file'); return; }
+      const data = await res.json();
+      currentPath = data.path;
+      document.getElementById('current-file').textContent = currentPath;
+      document.getElementById('editor-area').value = data.content;
+      setStatus(`Loaded ${currentPath}`);
+    }
+
+    async function saveFile() {
+      if (!currentPath) { setStatus('No file selected'); return; }
+      const body = document.getElementById('editor-area').value;
+      const res = await fetch(`/api/file?path=${encodeURIComponent(currentPath)}`, {
+        method: 'POST',
+        body
+      });
+      if (!res.ok) { setStatus('Save failed'); return; }
+      setStatus('Saved');
+    }
+
+    async function executeCommand() {
+      const input = document.getElementById('command-input');
+      const command = input.value.trim();
+      if (!command) { setStatus('No command'); return; }
+      const res = await fetch('/api/exec', { method: 'POST', body: command });
+      const data = await res.json();
+      const out = document.getElementById('terminal-output');
+      out.textContent += `\n$ ${data.cmd}\n${data.output}`;
+      out.scrollTop = out.scrollHeight;
+      input.value = '';
+    }
+
+    reloadExplorer('.');
+  </script>
+</body>
+</html>

--- a/src/gui.c
+++ b/src/gui.c
@@ -1,0 +1,66 @@
+#include "gui.h"
+
+#include <gtk/gtk.h>
+#include <webkit2/webkit2.h>
+
+struct activate_ctx {
+    const char *url;
+};
+
+static void on_destroy(GtkWidget *widget, gpointer data) {
+    (void)widget;
+    (void)data;
+    gtk_main_quit();
+}
+
+static void on_reload_clicked(GtkButton *button, gpointer user_data) {
+    (void)button;
+    WebKitWebView *view = WEBKIT_WEB_VIEW(user_data);
+    webkit_web_view_reload(view);
+}
+
+static void on_activate(GtkApplication *app, gpointer user_data) {
+    struct activate_ctx *ctx = (struct activate_ctx *)user_data;
+
+    GtkWidget *window = gtk_application_window_new(app);
+    gtk_window_set_title(GTK_WINDOW(window), "LKJ Desktop IDE");
+    gtk_window_set_default_size(GTK_WINDOW(window), 1280, 900);
+
+    GtkWidget *header = gtk_header_bar_new();
+    gtk_header_bar_set_show_close_button(GTK_HEADER_BAR(header), TRUE);
+    gtk_header_bar_set_title(GTK_HEADER_BAR(header), "LKJ – Local IDE");
+
+    GtkWidget *reload = gtk_button_new_with_label("Reload");
+    gtk_widget_set_tooltip_text(reload, "Refresh the IDE view");
+    gtk_header_bar_pack_end(GTK_HEADER_BAR(header), reload);
+
+    GtkWidget *view = webkit_web_view_new();
+    webkit_web_view_load_uri(WEBKIT_WEB_VIEW(view), ctx->url);
+
+    GtkWidget *scroller = gtk_scrolled_window_new(NULL, NULL);
+    gtk_container_add(GTK_CONTAINER(scroller), view);
+
+    GtkWidget *container = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
+    gtk_box_pack_start(GTK_BOX(container), header, FALSE, FALSE, 0);
+    gtk_box_pack_start(GTK_BOX(container), scroller, TRUE, TRUE, 0);
+
+    gtk_container_add(GTK_CONTAINER(window), container);
+
+    g_signal_connect(window, "destroy", G_CALLBACK(on_destroy), NULL);
+    g_signal_connect(reload, "clicked", G_CALLBACK(on_reload_clicked), view);
+
+    gtk_widget_show_all(window);
+}
+
+bool lkj_gui_supported(void) {
+    return gtk_init_check(NULL, NULL);
+}
+
+int lkj_launch_gui(const char *url) {
+    struct activate_ctx ctx = {.url = url};
+    GtkApplication *app = gtk_application_new("com.lkj.desktop", G_APPLICATION_DEFAULT_FLAGS);
+    g_signal_connect(app, "activate", G_CALLBACK(on_activate), &ctx);
+    int status = g_application_run(G_APPLICATION(app), 0, NULL);
+    g_object_unref(app);
+    return status;
+}

--- a/src/gui.h
+++ b/src/gui.h
@@ -1,0 +1,9 @@
+#ifndef LKJ_GUI_H
+#define LKJ_GUI_H
+
+#include <stdbool.h>
+
+bool lkj_gui_supported(void);
+int lkj_launch_gui(const char *url);
+
+#endif

--- a/src/main.c
+++ b/src/main.c
@@ -1,0 +1,73 @@
+#include "server.h"
+#include "gui.h"
+
+#include <pthread.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static const char *get_env_or(const char *name, const char *fallback) {
+    const char *value = getenv(name);
+    return value ? value : fallback;
+}
+
+struct server_thread_args {
+    struct lkj_server_config config;
+};
+
+static void *server_thread(void *arg) {
+    struct server_thread_args *args = (struct server_thread_args *)arg;
+    lkj_server_run(&args->config);
+    free(args);
+    return NULL;
+}
+
+int main(void) {
+    const char *host = get_env_or("LKJ_HOST", "0.0.0.0");
+    const char *port_str = get_env_or("LKJ_PORT", "8080");
+    const char *workspace = get_env_or("LKJ_WORKSPACE", ".");
+    const char *static_root = get_env_or("LKJ_STATIC", "assets");
+
+    char *end = NULL;
+    long port = strtol(port_str, &end, 10);
+    if (!end || *end != '\0' || port <= 0 || port > 65535) {
+        fprintf(stderr, "Invalid port: %s\n", port_str);
+        return 1;
+    }
+
+    struct lkj_server_config config = {
+        .host = host,
+        .port = (int)port,
+        .workspace_root = workspace,
+        .static_root = static_root,
+    };
+
+    printf("LKJ IDE listening on %s:%ld\n", host, port);
+    printf("Workspace: %s\n", workspace);
+    printf("Static assets: %s\n", static_root);
+
+    if (lkj_gui_supported()) {
+        struct server_thread_args *args = calloc(1, sizeof(*args));
+        if (!args) {
+            perror("calloc");
+            return 1;
+        }
+        args->config = config;
+        pthread_t tid;
+        if (pthread_create(&tid, NULL, server_thread, args) != 0) {
+            perror("pthread_create");
+            free(args);
+            return 1;
+        }
+        pthread_detach(tid);
+
+        char url[128];
+        const char *display_host = strcmp(host, "0.0.0.0") == 0 ? "127.0.0.1" : host;
+        snprintf(url, sizeof(url), "http://%s:%ld", display_host, port);
+        printf("Launching LKJ desktop window at %s\n", url);
+        return lkj_launch_gui(url);
+    }
+
+    printf("GUI unavailable, running server only.\n");
+    return lkj_server_run(&config);
+}

--- a/src/server.c
+++ b/src/server.c
@@ -1,0 +1,566 @@
+#define _POSIX_C_SOURCE 200809L
+
+#include "server.h"
+#include "util.h"
+
+#include <arpa/inet.h>
+#include <ctype.h>
+#include <dirent.h>
+#include <errno.h>
+#include <netinet/in.h>
+#include <pthread.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <strings.h>
+#include <sys/socket.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+struct client_ctx {
+    int fd;
+    struct lkj_server_config config;
+};
+
+static void *client_thread(void *arg);
+static int create_listener(const char *host, int port);
+static int send_response(int fd, const char *status, const char *content_type, const char *body, size_t body_len);
+static int send_file_response(int fd, const char *path);
+static int handle_request(int fd, const struct lkj_server_config *config, const char *req_buf, size_t req_len);
+static const char *skip_spaces(const char *p);
+static int read_request(int fd, char *buffer, size_t buffer_size, size_t *out_len);
+static int handle_api_request(int fd, const struct lkj_server_config *config, const char *method, const char *path, const char *query, const char *body, size_t body_len);
+static int handle_list(const struct lkj_server_config *config, int fd, const char *query);
+static int handle_read(const struct lkj_server_config *config, int fd, const char *query);
+static int handle_write(const struct lkj_server_config *config, int fd, const char *query, const char *body, size_t body_len);
+static int handle_exec(int fd, const char *body, size_t body_len);
+static int sanitize_and_join(const char *root, const char *relative, char *out, size_t out_size);
+static const char *query_param(const char *query, const char *key);
+static const char *case_insensitive_search(const char *haystack, const char *needle);
+
+int lkj_server_run(const struct lkj_server_config *config) {
+    int listener = create_listener(config->host, config->port);
+    if (listener < 0) {
+        return 1;
+    }
+
+    while (1) {
+        struct sockaddr_in client_addr;
+        socklen_t addrlen = sizeof(client_addr);
+        int client_fd = accept(listener, (struct sockaddr *)&client_addr, &addrlen);
+        if (client_fd < 0) {
+            perror("accept");
+            continue;
+        }
+
+        struct client_ctx *ctx = calloc(1, sizeof(struct client_ctx));
+        if (!ctx) {
+            perror("calloc");
+            close(client_fd);
+            continue;
+        }
+        ctx->fd = client_fd;
+        ctx->config = *config;
+
+        pthread_t tid;
+        if (pthread_create(&tid, NULL, client_thread, ctx) != 0) {
+            perror("pthread_create");
+            close(client_fd);
+            free(ctx);
+            continue;
+        }
+        pthread_detach(tid);
+    }
+}
+
+static void *client_thread(void *arg) {
+    struct client_ctx *ctx = (struct client_ctx *)arg;
+    char buffer[LKJ_BUFFER_SIZE];
+    size_t req_len = 0;
+    if (read_request(ctx->fd, buffer, sizeof(buffer), &req_len) == 0) {
+        handle_request(ctx->fd, &ctx->config, buffer, req_len);
+    }
+    close(ctx->fd);
+    free(ctx);
+    return NULL;
+}
+
+static int create_listener(const char *host, int port) {
+    int fd = socket(AF_INET, SOCK_STREAM, 0);
+    if (fd < 0) {
+        perror("socket");
+        return -1;
+    }
+
+    int opt = 1;
+    setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt));
+
+    struct sockaddr_in addr = {0};
+    addr.sin_family = AF_INET;
+    addr.sin_port = htons((uint16_t)port);
+    addr.sin_addr.s_addr = inet_addr(host);
+
+    if (bind(fd, (struct sockaddr *)&addr, sizeof(addr)) < 0) {
+        perror("bind");
+        close(fd);
+        return -1;
+    }
+
+    if (listen(fd, 16) < 0) {
+        perror("listen");
+        close(fd);
+        return -1;
+    }
+
+    return fd;
+}
+
+static int read_request(int fd, char *buffer, size_t buffer_size, size_t *out_len) {
+    size_t total = 0;
+    while (total < buffer_size - 1) {
+        ssize_t n = recv(fd, buffer + total, buffer_size - 1 - total, 0);
+        if (n < 0) {
+            perror("recv");
+            return -1;
+        }
+        if (n == 0) {
+            break;
+        }
+        total += (size_t)n;
+        buffer[total] = '\0';
+        if (strstr(buffer, "\r\n\r\n")) {
+            break;
+        }
+    }
+
+    const char *cl_header = case_insensitive_search(buffer, "Content-Length:");
+    size_t content_length = 0;
+    if (cl_header) {
+        cl_header += strlen("Content-Length:");
+        cl_header = skip_spaces(cl_header);
+        content_length = (size_t)strtoul(cl_header, NULL, 10);
+    }
+
+    const char *body_start = strstr(buffer, "\r\n\r\n");
+    if (!body_start) {
+        return -1;
+    }
+    body_start += 4;
+    size_t header_len = (size_t)(body_start - buffer);
+    size_t current_body = total - header_len;
+
+    while (current_body < content_length && total < buffer_size - 1) {
+        ssize_t n = recv(fd, buffer + total, buffer_size - 1 - total, 0);
+        if (n <= 0) {
+            return -1;
+        }
+        total += (size_t)n;
+        current_body += (size_t)n;
+    }
+
+    buffer[total] = '\0';
+    *out_len = total;
+    return 0;
+}
+
+static int handle_request(int fd, const struct lkj_server_config *config, const char *req_buf, size_t req_len) {
+    (void)req_len;
+    char method[8] = {0};
+    char path[LKJ_MAX_PATH] = {0};
+    char protocol[16] = {0};
+
+    const char *line_end = strstr(req_buf, "\r\n");
+    if (!line_end) {
+        return send_response(fd, "400 Bad Request", "text/plain", "Bad Request", strlen("Bad Request"));
+    }
+
+    if (sscanf(req_buf, "%7s %4095s %15s", method, path, protocol) != 3) {
+        return send_response(fd, "400 Bad Request", "text/plain", "Bad Request", strlen("Bad Request"));
+    }
+
+    char *query = strchr(path, '?');
+    if (query) {
+        *query++ = '\0';
+    }
+
+    const char *body = strstr(req_buf, "\r\n\r\n");
+    size_t body_len = 0;
+    if (body) {
+        body += 4;
+        body_len = (size_t)((req_buf + req_len) - body);
+    }
+
+    if (strcmp(path, "/") == 0 && strcmp(method, "GET") == 0) {
+        char index_path[LKJ_MAX_PATH];
+        snprintf(index_path, sizeof(index_path), "%s/index.html", config->static_root);
+        return send_file_response(fd, index_path);
+    }
+
+    if (strncmp(path, "/assets/", 8) == 0 && strcmp(method, "GET") == 0) {
+        char asset_path[LKJ_MAX_PATH];
+        snprintf(asset_path, sizeof(asset_path), "%s/%s", config->static_root, path + 8);
+        return send_file_response(fd, asset_path);
+    }
+
+    if (strncmp(path, "/api/", 5) == 0) {
+        return handle_api_request(fd, config, method, path, query, body ? body : "", body_len);
+    }
+
+    return send_response(fd, "404 Not Found", "text/plain", "Not Found", strlen("Not Found"));
+}
+
+static int send_response(int fd, const char *status, const char *content_type, const char *body, size_t body_len) {
+    char header[512];
+    int header_len = snprintf(header, sizeof(header),
+                              "HTTP/1.1 %s\r\n"
+                              "Content-Type: %s\r\n"
+                              "Content-Length: %zu\r\n"
+                              "Connection: close\r\n\r\n",
+                              status, content_type, body_len);
+    if (header_len < 0 || (size_t)header_len >= sizeof(header)) {
+        return -1;
+    }
+    if (send(fd, header, (size_t)header_len, 0) < 0) {
+        return -1;
+    }
+    if (body_len > 0 && send(fd, body, body_len, 0) < 0) {
+        return -1;
+    }
+    return 0;
+}
+
+static int send_file_response(int fd, const char *path) {
+    FILE *f = fopen(path, "rb");
+    if (!f) {
+        const char *msg = "Not Found";
+        return send_response(fd, "404 Not Found", "text/plain", msg, strlen(msg));
+    }
+
+    fseek(f, 0, SEEK_END);
+    long size = ftell(f);
+    fseek(f, 0, SEEK_SET);
+    if (size < 0 || size > LKJ_BUFFER_SIZE) {
+        fclose(f);
+        const char *msg = "File Too Large";
+        return send_response(fd, "413 Payload Too Large", "text/plain", msg, strlen(msg));
+    }
+
+    char *content = malloc((size_t)size);
+    if (!content) {
+        fclose(f);
+        return send_response(fd, "500 Internal Server Error", "text/plain", "OOM", 3);
+    }
+
+    size_t read_bytes = fread(content, 1, (size_t)size, f);
+    if (read_bytes != (size_t)size) {
+        fclose(f);
+        free(content);
+        const char *msg = "Failed to read file";
+        return send_response(fd, "500 Internal Server Error", "text/plain", msg, strlen(msg));
+    }
+    fclose(f);
+
+    const char *mime = lkj_mime_type(path);
+    int res = send_response(fd, "200 OK", mime, content, (size_t)size);
+    free(content);
+    return res;
+}
+
+static int handle_api_request(int fd, const struct lkj_server_config *config, const char *method, const char *path, const char *query, const char *body, size_t body_len) {
+    if (strcmp(path, "/api/files") == 0 && strcmp(method, "GET") == 0) {
+        return handle_list(config, fd, query);
+    }
+    if (strcmp(path, "/api/file") == 0 && strcmp(method, "GET") == 0) {
+        return handle_read(config, fd, query);
+    }
+    if (strcmp(path, "/api/file") == 0 && strcmp(method, "POST") == 0) {
+        return handle_write(config, fd, query, body, body_len);
+    }
+    if (strcmp(path, "/api/exec") == 0 && strcmp(method, "POST") == 0) {
+        return handle_exec(fd, body, body_len);
+    }
+    const char *msg = "Unsupported";
+    return send_response(fd, "405 Method Not Allowed", "text/plain", msg, strlen(msg));
+}
+
+static const char *query_param(const char *query, const char *key) {
+    if (!query || !key) return NULL;
+    size_t key_len = strlen(key);
+    const char *p = query;
+    while (p && *p) {
+        if (strncmp(p, key, key_len) == 0 && p[key_len] == '=') {
+            return p + key_len + 1;
+        }
+        p = strchr(p, '&');
+        if (p) ++p;
+    }
+    return NULL;
+}
+
+static int sanitize_and_join(const char *root, const char *relative, char *out, size_t out_size) {
+    if (!relative || strstr(relative, "..")) {
+        return -1;
+    }
+    while (*relative == '/') {
+        relative++;
+    }
+    if (snprintf(out, out_size, "%s/%s", root, relative) >= (int)out_size) {
+        return -1;
+    }
+    return 0;
+}
+
+static int handle_list(const struct lkj_server_config *config, int fd, const char *query) {
+    const char *raw_path = query_param(query, "path");
+    char decoded[LKJ_MAX_PATH];
+    if (!raw_path || !lkj_url_decode(raw_path, decoded, sizeof(decoded))) {
+        const char *msg = "Missing path";
+        return send_response(fd, "400 Bad Request", "text/plain", msg, strlen(msg));
+    }
+
+    char abs_path[LKJ_MAX_PATH];
+    if (sanitize_and_join(config->workspace_root, decoded, abs_path, sizeof(abs_path)) != 0) {
+        const char *msg = "Invalid path";
+        return send_response(fd, "400 Bad Request", "text/plain", msg, strlen(msg));
+    }
+
+    DIR *dir = opendir(abs_path);
+    if (!dir) {
+        const char *msg = "Cannot open directory";
+        return send_response(fd, "404 Not Found", "text/plain", msg, strlen(msg));
+    }
+
+    char response[LKJ_BUFFER_SIZE];
+    size_t offset = 0;
+    offset += (size_t)snprintf(response + offset, sizeof(response) - offset, "{\"path\":\"%s\",\"entries\":[", decoded);
+
+    struct dirent *entry;
+    int first = 1;
+    while ((entry = readdir(dir)) != NULL) {
+        if (strcmp(entry->d_name, ".") == 0 || strcmp(entry->d_name, "..") == 0) {
+            continue;
+        }
+        if (!first) {
+            response[offset++] = ',';
+        }
+        first = 0;
+
+        char item_path[LKJ_MAX_PATH];
+        int name_len = snprintf(item_path, sizeof(item_path), "%s/%s", abs_path, entry->d_name);
+        if (name_len < 0 || name_len >= (int)sizeof(item_path)) {
+            continue;
+        }
+        struct stat st;
+        stat(item_path, &st);
+        const char *kind = S_ISDIR(st.st_mode) ? "dir" : "file";
+        offset += (size_t)snprintf(response + offset, sizeof(response) - offset,
+                                   "{\"name\":\"%s\",\"kind\":\"%s\",\"size\":%ld}",
+                                   entry->d_name, kind, (long)st.st_size);
+        if (offset >= sizeof(response)) {
+            break;
+        }
+    }
+    closedir(dir);
+
+    offset += (size_t)snprintf(response + offset, sizeof(response) - offset, "]}");
+    return send_response(fd, "200 OK", "application/json", response, offset);
+}
+
+static int handle_read(const struct lkj_server_config *config, int fd, const char *query) {
+    const char *raw_path = query_param(query, "path");
+    char decoded[LKJ_MAX_PATH];
+    if (!raw_path || !lkj_url_decode(raw_path, decoded, sizeof(decoded))) {
+        const char *msg = "Missing path";
+        return send_response(fd, "400 Bad Request", "text/plain", msg, strlen(msg));
+    }
+
+    char abs_path[LKJ_MAX_PATH];
+    if (sanitize_and_join(config->workspace_root, decoded, abs_path, sizeof(abs_path)) != 0) {
+        const char *msg = "Invalid path";
+        return send_response(fd, "400 Bad Request", "text/plain", msg, strlen(msg));
+    }
+
+    FILE *f = fopen(abs_path, "rb");
+    if (!f) {
+        const char *msg = "Cannot open file";
+        return send_response(fd, "404 Not Found", "text/plain", msg, strlen(msg));
+    }
+    fseek(f, 0, SEEK_END);
+    long size = ftell(f);
+    fseek(f, 0, SEEK_SET);
+    if (size < 0 || size >= (long)(LKJ_BUFFER_SIZE - 64)) {
+        fclose(f);
+        const char *msg = "File too large";
+        return send_response(fd, "413 Payload Too Large", "text/plain", msg, strlen(msg));
+    }
+
+    char *content = malloc((size_t)size + 1);
+    if (!content) {
+        fclose(f);
+        return send_response(fd, "500 Internal Server Error", "text/plain", "OOM", 3);
+    }
+    size_t read_bytes = fread(content, 1, (size_t)size, f);
+    content[size] = '\0';
+    fclose(f);
+    if (read_bytes != (size_t)size) {
+        free(content);
+        const char *msg = "Failed to read file";
+        return send_response(fd, "500 Internal Server Error", "text/plain", msg, strlen(msg));
+    }
+
+    char response[LKJ_BUFFER_SIZE];
+    size_t offset = 0;
+    offset += (size_t)snprintf(response + offset, sizeof(response) - offset, "{\"path\":\"%s\",\"content\":\"", decoded);
+    for (long i = 0; i < size && offset + 4 < sizeof(response); ++i) {
+        unsigned char c = (unsigned char)content[i];
+        switch (c) {
+            case '"':
+            case '\\':
+                response[offset++] = '\\';
+                response[offset++] = (char)c;
+                break;
+            case '\n':
+                response[offset++] = '\\';
+                response[offset++] = 'n';
+                break;
+            case '\r':
+                response[offset++] = '\\';
+                response[offset++] = 'r';
+                break;
+            case '\t':
+                response[offset++] = '\\';
+                response[offset++] = 't';
+                break;
+            default:
+                if (isprint(c)) {
+                    response[offset++] = (char)c;
+                } else {
+                    response[offset++] = ' ';
+                }
+        }
+    }
+    free(content);
+    offset += (size_t)snprintf(response + offset, sizeof(response) - offset, "\"}");
+
+    return send_response(fd, "200 OK", "application/json", response, offset);
+}
+
+static int handle_write(const struct lkj_server_config *config, int fd, const char *query, const char *body, size_t body_len) {
+    const char *raw_path = query_param(query, "path");
+    char decoded[LKJ_MAX_PATH];
+    if (!raw_path || !lkj_url_decode(raw_path, decoded, sizeof(decoded))) {
+        const char *msg = "Missing path";
+        return send_response(fd, "400 Bad Request", "text/plain", msg, strlen(msg));
+    }
+
+    char abs_path[LKJ_MAX_PATH];
+    if (sanitize_and_join(config->workspace_root, decoded, abs_path, sizeof(abs_path)) != 0) {
+        const char *msg = "Invalid path";
+        return send_response(fd, "400 Bad Request", "text/plain", msg, strlen(msg));
+    }
+
+    FILE *f = fopen(abs_path, "wb");
+    if (!f) {
+        const char *msg = "Cannot open file";
+        return send_response(fd, "403 Forbidden", "text/plain", msg, strlen(msg));
+    }
+
+    size_t written = fwrite(body, 1, body_len, f);
+    fclose(f);
+    if (written != body_len) {
+        const char *msg = "Failed to write file";
+        return send_response(fd, "500 Internal Server Error", "text/plain", msg, strlen(msg));
+    }
+
+    const char *msg = "{\"status\":\"ok\"}";
+    return send_response(fd, "200 OK", "application/json", msg, strlen(msg));
+}
+
+static int handle_exec(int fd, const char *body, size_t body_len) {
+    if (body_len == 0) {
+        const char *msg = "Missing command";
+        return send_response(fd, "400 Bad Request", "text/plain", msg, strlen(msg));
+    }
+
+    char cmd[256];
+    size_t len = body_len < sizeof(cmd) - 1 ? body_len : sizeof(cmd) - 1;
+    memcpy(cmd, body, len);
+    cmd[len] = '\0';
+
+    FILE *p = popen(cmd, "r");
+    if (!p) {
+        const char *msg = "Cannot execute";
+        return send_response(fd, "500 Internal Server Error", "text/plain", msg, strlen(msg));
+    }
+
+    char output[LKJ_BUFFER_SIZE];
+    size_t n = fread(output, 1, sizeof(output) - 1, p);
+    output[n] = '\0';
+    pclose(p);
+
+    char response[LKJ_BUFFER_SIZE];
+    size_t offset = (size_t)snprintf(response, sizeof(response), "{\"cmd\":\"");
+    for (size_t i = 0; i < len && offset + 4 < sizeof(response); ++i) {
+        char c = cmd[i];
+        if (c == '\\' || c == '"') {
+            response[offset++] = '\\';
+            response[offset++] = c;
+        } else if (c == '\n') {
+            response[offset++] = '\\';
+            response[offset++] = 'n';
+        } else {
+            response[offset++] = c;
+        }
+    }
+    offset += (size_t)snprintf(response + offset, sizeof(response) - offset, "\",\"output\":\"");
+    for (size_t i = 0; i < n && offset + 4 < sizeof(response); ++i) {
+        unsigned char c = (unsigned char)output[i];
+        switch (c) {
+            case '"':
+            case '\\':
+                response[offset++] = '\\';
+                response[offset++] = (char)c;
+                break;
+            case '\n':
+                response[offset++] = '\\';
+                response[offset++] = 'n';
+                break;
+            case '\r':
+                response[offset++] = '\\';
+                response[offset++] = 'r';
+                break;
+            default:
+                if (isprint(c)) {
+                    response[offset++] = (char)c;
+                } else {
+                    response[offset++] = ' ';
+                }
+        }
+    }
+    offset += (size_t)snprintf(response + offset, sizeof(response) - offset, "\"}");
+
+    return send_response(fd, "200 OK", "application/json", response, offset);
+}
+
+static const char *skip_spaces(const char *p) {
+    while (p && *p && isspace((unsigned char)*p)) {
+        ++p;
+    }
+    return p;
+}
+
+static const char *case_insensitive_search(const char *haystack, const char *needle) {
+    if (!haystack || !needle) {
+        return NULL;
+    }
+    size_t needle_len = strlen(needle);
+    for (const char *p = haystack; *p; ++p) {
+        if (tolower((unsigned char)*p) == tolower((unsigned char)*needle)) {
+            if (strncasecmp(p, needle, needle_len) == 0) {
+                return p;
+            }
+        }
+    }
+    return NULL;
+}

--- a/src/server.h
+++ b/src/server.h
@@ -1,0 +1,18 @@
+#ifndef LKJ_SERVER_H
+#define LKJ_SERVER_H
+
+#include <stddef.h>
+
+#define LKJ_MAX_PATH 4096
+#define LKJ_BUFFER_SIZE 65536
+
+struct lkj_server_config {
+    const char *host;
+    int port;
+    const char *workspace_root;
+    const char *static_root;
+};
+
+int lkj_server_run(const struct lkj_server_config *config);
+
+#endif

--- a/src/util.c
+++ b/src/util.c
@@ -1,0 +1,52 @@
+#include "util.h"
+
+#include <ctype.h>
+#include <string.h>
+
+size_t lkj_strlcpy(char *dst, const char *src, size_t size) {
+    size_t i;
+    for (i = 0; i + 1 < size && src[i]; ++i) {
+        dst[i] = src[i];
+    }
+    if (size > 0) {
+        dst[i] = '\0';
+    }
+    while (src[i]) {
+        ++i;
+    }
+    return i;
+}
+
+bool lkj_url_decode(const char *src, char *dest, size_t dest_size) {
+    size_t di = 0;
+    for (size_t i = 0; src[i] && di + 1 < dest_size; ++i) {
+        if (src[i] == '%' && isxdigit((unsigned char)src[i + 1]) && isxdigit((unsigned char)src[i + 2])) {
+            int high = isdigit((unsigned char)src[i + 1]) ? src[i + 1] - '0' : tolower((unsigned char)src[i + 1]) - 'a' + 10;
+            int low = isdigit((unsigned char)src[i + 2]) ? src[i + 2] - '0' : tolower((unsigned char)src[i + 2]) - 'a' + 10;
+            dest[di++] = (char)((high << 4) | low);
+            i += 2;
+        } else if (src[i] == '+') {
+            dest[di++] = ' ';
+        } else {
+            dest[di++] = src[i];
+        }
+    }
+    dest[di] = '\0';
+    return di + 1 < dest_size;
+}
+
+const char *lkj_mime_type(const char *path) {
+    const char *ext = strrchr(path, '.');
+    if (!ext) {
+        return "text/plain";
+    }
+
+    if (strcmp(ext, ".html") == 0) return "text/html";
+    if (strcmp(ext, ".js") == 0) return "application/javascript";
+    if (strcmp(ext, ".css") == 0) return "text/css";
+    if (strcmp(ext, ".json") == 0) return "application/json";
+    if (strcmp(ext, ".svg") == 0) return "image/svg+xml";
+    if (strcmp(ext, ".png") == 0) return "image/png";
+
+    return "application/octet-stream";
+}

--- a/src/util.h
+++ b/src/util.h
@@ -1,0 +1,11 @@
+#ifndef LKJ_UTIL_H
+#define LKJ_UTIL_H
+
+#include <stddef.h>
+#include <stdbool.h>
+
+size_t lkj_strlcpy(char *dst, const char *src, size_t size);
+bool lkj_url_decode(const char *src, char *dest, size_t dest_size);
+const char *lkj_mime_type(const char *path);
+
+#endif


### PR DESCRIPTION
## Summary
- add GTK/WebKit-powered desktop window that embeds the LKJ web IDE
- launch the web server in a background thread when GUI is available, otherwise run headless
- update build flags and documentation for GUI dependencies

## Testing
- make clean && make

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6939b841cd7483308c2d626c9e75124f)